### PR TITLE
Credits

### DIFF
--- a/ascension/doc/readme-ascension.html
+++ b/ascension/doc/readme-ascension.html
@@ -1072,7 +1072,7 @@
                     <li>Fixed not existing spell name SPIN822b.BAM to SPIN822.BAM</li>
                     <li>Fix for msg2po regex not supporting double quotes</li>
                     <li>English proofread of whitespace, punctuation and such by Jazira</li>
-                    <li>Marjor update of French translation by Jazira</li>
+                    <li>Marjor update of French translation by Jazira, Selphira and Machiavelique</li>
                     <li>Minor update of Russian translation by abalabokhin</li>
                     <li>Minor update of Czech, Chinese, German, Italian, Polish, Portuguese and Spanish translation</li>
                 </ul>


### PR DESCRIPTION
Hey,

I just added a few credits.

It seems that a few problems have been integrated over the last few days:
- \ascension\lang\french\ascension.tra @1031 should have colon, not a comma (@1031 = "Symbole : Lenteur"). Be careful, in French, there is a space BEFORE and after the colon. ;)
- \ascension\lang\french\items-ee.tra @3004 special characters (è, à, û) seem to be corupted. (@3004 = "Quoi qu'il en soit, elle reste une arme formidable... et Sarevok prévient qu'elle deviendrait très difficile (voire impossible) à utiliser dans les mains de quelqu'un qui ne fût pas un semeur de mort.").

Everything else is ok, keep the good work.

Thank you. :)


